### PR TITLE
Updating references of tenant booker app

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a mission that can help you get started with SAP Integration Suite:
 You will be provided with a user account (***UserXX***) that authenticates to SAP Cloud Identity Service to log in to the SAP Integration Suite sandbox Account set up for you. 
 
 > [!IMPORTANT]
-> Your instructor will provide you with the tenant URL, username, and password to access the tenant. 
+> Your instructor will provide you with the tenant URL, username, and password to access the tenant.
 
 You will also need a testing tool installed on your local machine to connect to the IFlows and API. In this hands-on, we will be referencing screenshots executed in [Bruno](https://www.usebruno.com/) as the testing client. You are free to use any tool of your choice, e,g, Postman, Insomnia, SOAPUI etc. 
 

--- a/exercises/ex1/README.md
+++ b/exercises/ex1/README.md
@@ -8,7 +8,7 @@ In this exercise, you will
 
 ## Explore SAP Integration Suite tooling
 
-Log in to the SAP Integration Suite tenant using the credentials from the tenant booker app. Now let´s explore the different capabilities and navigations of SAP Integration Suite tooling. <br>
+Log in to the SAP Integration Suite tenant using the credentials from the shared document. Now let´s explore the different capabilities and navigations of SAP Integration Suite tooling. <br>
 
 > [!NOTE]
 > The screenshots below show more items than the ones you have access to with your user. This is because your user has only the access required to complete the exercises. The screenshots were taken with a user who has admin access in the tenant and the intention is to show you all the capabilities available in SAP Integration Suite.

--- a/exercises/ex4/README.md
+++ b/exercises/ex4/README.md
@@ -148,10 +148,12 @@ Having completed these steps, you are now ready to test the interface. To do thi
 </soapenv:Envelope>
 ```
 
-7. Switch to tab **Auth** and choose **OAuth 2.0**. Grant Type must be set to **Client Credentials**. The authentication details can be found in the booker application. Past them and press **Get Access Token**.
+> [!IMPORTANT]
+> The credentials needed in the step below are included in the document shared by your instructor (**ESB Credentials** section). Please use the credentials provided in the document to authenticate the request.
 
-<br>![image](/exercises/ex4/images/Auth_Bruno.png)  
-<br>![image](/exercises/ex4/images/Auth_Booker.png) 
+7. Switch to tab **Auth** and choose **OAuth 2.0**. Grant Type must be set to **Client Credentials**. The authentication details can be found in the shared document (**ESB Credentials** section). Past them and press **Get Access Token**.
+
+<br>![image](/exercises/ex4/images/Auth_Bruno.png) 
 
 
 8. The response contains the Access Token. **Copy** the **"access_token"** value to the clipboard as this is required in the next step for authentication.

--- a/exercises/ex5/README.md
+++ b/exercises/ex5/README.md
@@ -170,9 +170,10 @@ We will continue using Bruno for testing, the tool used in ex4 as well. Create a
 
 ![](/exercises/ex5/images/ex5_1_4.png)
 
-<br> Now refer back to the TenantBooker app and the credentials we did save earlier. Copy the Token URL and client credentials for the 'Process Integration' section.
+> [!IMPORTANT]
+> The credentials needed in the step below are included in the document shared by your instructor (**ESB Credentials** section).
 
-![](/exercises/ex5/images/tenantbooker_1.png)
+<br> Now refer back to the shared document and the credentials we did save earlier. Copy the Token URL and client credentials for the 'ESB Credentials' section.
 
 <br> Select the 'Client Credentials' grant type and copy the token URL and client credentials in the respective fields. Invoke the 'Get Access Token' button.
 
@@ -206,9 +207,11 @@ We will continue using Bruno for testing, the tool used in ex4 as well. Create a
 
 ![](/exercises/ex5/images/ex5_1_12.png)
 
-<br>Of course, we need to head back to the tenant booker app and now copy the right set of client credentials labeled 'API Management API Access...'
 
-![](/exercises/ex5/images/tenantbooker_2.png)
+> [!IMPORTANT]
+> The credentials needed in the step below are included in the document shared by your instructor (**API Management API Access** section).
+
+Of course, we need to head back to the shared document and now copy the right set of client credentials labeled 'API Management API Access...'
 
 <br> Hit your testing client again, only this time with the right set of credentials. The scope (APIArtefactUser) attached to the access token will indicate so. 
 


### PR DESCRIPTION
Given that we will not use the tenant booker app, I've updated the references in the repo. It now mentions the document that will be shared with participants on the day of the event.